### PR TITLE
Improvements to EE disable template editor

### DIFF
--- a/ext.disable_template_editor.php
+++ b/ext.disable_template_editor.php
@@ -31,7 +31,7 @@ class Disable_template_editor_ext
 	public $docs_url		= 'http://getbunch.com/';
 	public $name			= 'Disable Template Editor';
 	public $settings_exist	= 'n';
-	public $version			= '1.0.1';
+	public $version			= '1.0.2';
 
 	private $EE;
 

--- a/ext.disable_template_editor.php
+++ b/ext.disable_template_editor.php
@@ -87,15 +87,14 @@ class Disable_template_editor_ext
 	public function inject_cp_js()
 	{
 		$str = '$(function() {' .
-			'$("#templateEditor input[type=\"submit\"]").hide();' .
 			'$("#templateEditor input[name=\"save_template_file\"]").parent().hide();' .
 			'$("#templateEditor #template_details > p").html("Read Only (Source Controlled) &ndash;" + $("#templateEditor #template_details > p").html());' .
 			'$("#templateEditor textarea[name=\"template_data\"]").attr("readonly", "readonly");' .
 			'$("#templateGroups .newTemplate").hide();' .
-			'$("label[for=\"name_of_template_group\"]").parent().parent().hide();' .
-			'$(".templateGrouping div.newTemplate:eq(1)").hide();' .
-			'$(".templateGrouping div.newTemplate:eq(0)").hide();' .
+			'$(".templateGrouping div.newTemplate:nth-child(2)").hide();' .
+			'$(".templateGrouping div.newTemplate:nth-child(1)").hide();' .
 			'$(".templateEditorTop > h2").html("Template Management (Under Source Control)");' .
+			'$(".templateEditorTop").append("<div style=\'clear: both\'>All templates &amp; template groups must be created and edited via the templates folder on the filesystem.</div>");' .
 			'$(".templateTable input[name=\"template_name\"]").attr("disabled", "disabled");' .
 			'$(".templateTable .template_manager_template_name").html($(".templateTable .template_manager_template_name").html() + " (Read Only)");' .
 		'});';

--- a/ext.disable_template_editor.php
+++ b/ext.disable_template_editor.php
@@ -97,6 +97,7 @@ class Disable_template_editor_ext
 			'$(".templateEditorTop").append("<div style=\'clear: both\'>All templates &amp; template groups must be created and edited via the templates folder on the filesystem.</div>");' .
 			'$(".templateTable input[name=\"template_name\"]").attr("disabled", "disabled");' .
 			'$(".templateTable .template_manager_template_name").html($(".templateTable .template_manager_template_name").html() + " (Read Only)");' .
+			'$(".templateTable tr td.cellRight").html("--");' .			
 		'});';
 
 		return !$this->EE->extensions->last_call ? $str : $this->EE->extensions->last_call . $str;


### PR DESCRIPTION
Hey-

Thanks for writing the EE disable template editor extension. I've made a few tweaks that I wanted to share:
- unhid submit button on template view page, so preferences & settings can be saved
- used nth-child() rather than eq() for the 'new template' and 'delete group' buttons. This fixes a bug where the buttons would show up if you had more than one template group
- Added help text for anybody who gets confused.
- Remove the 'delete template' link so templates have to be deleted from the filesystem

Small tweaks; these have all been useful for me in my multi-developer group. Hopefully you'll agree.

David
